### PR TITLE
Improve API bootstrap and defaults for reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ pgdata/
 redis-data/
 uploads/
 
+# --- Локальное хранилище SQLite по умолчанию ---
+api/storage/
+
 # --- Почта / тестовые вложения ---
 mailhog/
 tmp/

--- a/api/deps.py
+++ b/api/deps.py
@@ -1,24 +1,85 @@
-from fastapi import Depends, Query
-from sqlalchemy.orm import sessionmaker, Session
-from sqlalchemy import create_engine
+"""Infrastructure dependencies shared across the application."""
+
+from __future__ import annotations
+
 import os
+from pathlib import Path
+from typing import Iterable
 
-DATABASE_URL = os.environ["DATABASE_URL"]
+from fastapi import Query
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session, sessionmaker
 
-engine = create_engine(DATABASE_URL, future=True, pool_pre_ping=True)
+
+DEFAULT_SQLITE_URL = "sqlite:///./storage/hermes.db"
+
+
+def _ensure_sqlite_path(database_url: str) -> None:
+    """Create a directory for SQLite DBs before engine initialisation."""
+
+    if not database_url.startswith("sqlite"):
+        return
+
+    db_path = database_url.split("///", maxsplit=1)[-1]
+    if not db_path:
+        return
+
+    # ``sqlite:///:memory:`` не требует подготовки, а обычные файлы — да.
+    if db_path == ":memory:":
+        return
+
+    Path(db_path).expanduser().resolve().parent.mkdir(parents=True, exist_ok=True)
+
+
+def _create_engine() -> Engine:
+    database_url = os.getenv("DATABASE_URL", DEFAULT_SQLITE_URL)
+    _ensure_sqlite_path(database_url)
+
+    connect_args = {"check_same_thread": False} if database_url.startswith("sqlite") else {}
+
+    try:
+        return create_engine(
+            database_url,
+            future=True,
+            pool_pre_ping=True,
+            connect_args=connect_args,
+        )
+    except SQLAlchemyError as exc:  # pragma: no cover - защитное поведение
+        # Исключение перехватывается, чтобы сообщить более осмысленную ошибку при старте.
+        msg = f"Unable to initialise database engine for URL {database_url!r}: {exc}"
+        raise RuntimeError(msg) from exc
+
+
+if not (__package__ or "").startswith("api."):
+    import models as models_module  # type: ignore
+else:  # pragma: no cover - ветка для запуска как пакет
+    from . import models as models_module
+
+
+engine = _create_engine()
 SessionLocal = sessionmaker(engine, expire_on_commit=False, future=True)
+models_module.Base.metadata.create_all(bind=engine)
 
-def get_db() -> Session:
-    with SessionLocal() as s:
-        yield s
+
+def get_db() -> Iterable[Session]:
+    """FastAPI dependency returning a scoped SQLAlchemy session."""
+
+    with SessionLocal() as session:
+        yield session
 
 class Page:
+    """Simple pagination descriptor with sane defaults and bounds."""
+
     def __init__(self, page: int = 1, size: int = 20, max_size: int = 100):
         self.page = max(page, 1)
         self.size = min(max(size, 1), max_size)
 
 def pagination(
-    page: int = Query(1, ge=1),
-    size: int = Query(20, ge=1, le=100),
+    page: int = Query(1, ge=1, description="Номер страницы (>= 1)"),
+    size: int = Query(20, ge=1, le=100, description="Размер страницы (1..100)"),
 ) -> Page:
+    """Factory dependency that clamps incoming pagination parameters."""
+
     return Page(page, size)

--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,16 @@
+"""Application bootstrap for the FastAPI backend."""
+
+from pathlib import Path
+import sys
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from routers import auth, students, dashboard
+
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from routers import auth, dashboard, students  # type: ignore
+else:
+    from .routers import auth, dashboard, students
 
 app = FastAPI(title="Tutor MVP", version="0.1")
 

--- a/api/routers/dashboard.py
+++ b/api/routers/dashboard.py
@@ -1,8 +1,17 @@
+from pathlib import Path
+import sys
+
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import select, func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
-from deps import get_db
-from models import Student, Lesson
+
+if not (__package__ or "").startswith("api."):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from deps import get_db
+    from models import Lesson, Student
+else:  # pragma: no cover - ветка для запуска как пакет
+    from ..deps import get_db
+    from ..models import Lesson, Student
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary
- add a SQLite fallback with automatic schema creation so the API boots without external config
- make FastAPI bootstrap and routers resilient to different import contexts
- replace optional EmailStr dependency with lightweight validation and optimise student pagination
- ignore the generated SQLite storage directory

## Testing
- pytest api/tests/test_smoke.py -q
